### PR TITLE
Update event handler name

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function netlifyPlugin(conf) {
   return {
 
     // Hook into lifecycle
-    init: (data) => {
+    onInit: (data) => {
       // set up our caching location
       // if we are in prod, use the persisting cache location
       // otherwise use a local, relative location
@@ -121,7 +121,7 @@ function netlifyPlugin(conf) {
       };
     },
 
-    postInstall: (data) => {
+    onPostInstall: (data) => {
       // fetch and cache all the feeds
       conf.feeds.forEach(feed => {
         var tll = feed.ttl ? feed.ttl : null;


### PR DESCRIPTION
Hi there,

Thanks a lot for working on this Netlify Build plugin!

As the Netlify Build Beta is moving forward, we are making some changes to the shape of the plugin, hoping to make it clearer to plugin authors. To that end, methods names now need to be prefixed with `on`. For example `build()` is now called `onBuild()`.
This PR implements this new name.

Please note that we will release those new method names on Monday both locally (Netlify CLI) and in the CI, so this PR should not be merged until then. I just thought I would give you some heads up!

Thanks again!