### PR TITLE
Add `netlify-plugin` keyword in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "keywords": [
     "netlify",
+    "netlify-plugin",
     "rss",
     "ssg",
     "feed",


### PR DESCRIPTION
This adds the `netlify-plugin` keyword in `package.json` to make this plugin discoverable on npm.