### PR TITLE
Add `bugs` URL to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/philhawksworth/netlify-plugin-fetch-feeds"
   },
+  "bugs": {
+    "url": "https://github.com/philhawksworth/netlify-plugin-fetch-feeds/issues"
+  },
   "keywords": [
     "netlify",
     "rss",


### PR DESCRIPTION
This adds the `bugs` field to `package.json`. This field is used in error messages when the plugin fails.