### PR TITLE
Option to directly download a feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .netlify
 *.tgz
+_tmp

--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,12 @@ This plugin will fetch the specified feeds and stash their data prior to the exe
       name = "netlify"
       url = "https://www.netlify.com/blog/index.xml"
       ttl = 86400
+    [[plugins.inputs.feeds]]
+      # Content will not be processed if type is set to "direct". The path will be taken as-is.
+      type = "direct"
+      name = "Netlify_logo.svg"
+      url = "https://en.wikipedia.org/wiki/Netlify#/media/File:Netlify_logo.svg"
+      ttl = 86400
 ```
 
 

--- a/fetchData.js
+++ b/fetchData.js
@@ -1,0 +1,19 @@
+const fetch   = require('node-fetch');
+const parser  = require('xml2json');
+
+module.exports = async function fetchData (feed) {
+  var data = await fetch(feed.url)
+    .then(async function(res) {
+
+      // Stash all data as JSON.
+      let contentType = res.headers.get('content-type').toLowerCase();
+      if(contentType == 'application/json') {
+        return res.json();
+      } else {
+        let text = await res.text();
+        let json = parser.toJson(text);
+        return JSON.parse(json);
+      }
+    });
+  return JSON.stringify(data);
+};

--- a/fetchData.js
+++ b/fetchData.js
@@ -1,19 +1,19 @@
-const fetch   = require('node-fetch');
-const parser  = require('xml2json');
+const fetch  = require('node-fetch');
+const parser = require('xml2json');
 
 module.exports = async function fetchData (feed) {
-  var data = await fetch(feed.url)
-    .then(async function(res) {
+  const res = await fetch(feed.url);
+  if (feed.type === 'direct') {
+    // Directly passing data through
+    return new Uint8Array(await res.arrayBuffer());
+  }
 
-      // Stash all data as JSON.
-      let contentType = res.headers.get('content-type');
-      if(/^application\/json$/i.test(contentType)) {
-        return res.json();
-      } else {
-        let text = await res.text();
-        let json = parser.toJson(text);
-        return JSON.parse(json);
-      }
-    });
-  return JSON.stringify(data);
-};
+  const contentType = res.headers.get('content-type');
+  if (/^application\/json$/i.test(contentType)) {
+    // Reformat JSON
+    return JSON.stringify(await res.json());
+  }
+
+  // Turning structured text into JSON
+  return parser.toJson(await res.text());
+}

--- a/fetchData.js
+++ b/fetchData.js
@@ -6,8 +6,8 @@ module.exports = async function fetchData (feed) {
     .then(async function(res) {
 
       // Stash all data as JSON.
-      let contentType = res.headers.get('content-type').toLowerCase();
-      if(contentType == 'application/json') {
+      let contentType = res.headers.get('content-type');
+      if(/^application\/json$/i.test(contentType)) {
         return res.json();
       } else {
         let text = await res.text();

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
-const fs      = require('fs');
-const fetch   = require('node-fetch');
-const parser  = require('xml2json');
-const chalk   = require('chalk');
-
+const fs        = require('fs');
+const chalk     = require('chalk');
+const fetchData = require('./fetchData');
 
 module.exports = {
 
@@ -21,23 +19,10 @@ module.exports = {
       }
       // Or if it's not cached, let's fetch it and cache it.
       else {
-        var data = await fetch(feed.url)
-          .then(async function(res) {
+        const data = await fetchData(feed);
 
-            // Stash all data as JSON.
-            let contentType = res.headers.get('content-type').toLowerCase();
-            if(contentType == 'application/json') {
-              return res.json();
-            } else {
-              let text = await res.text();
-              let json = parser.toJson(text);
-              return JSON.parse(json);
-            }
-          });
-
-        // put the fetched data in the daa file, and then cahce it.
-        // await saveFeed(JSON.stringify(data), dataFilePath);
-        await fs.writeFileSync(dataFilePath, JSON.stringify(data));
+        // put the fetched data in the daa file, and then cache it.
+        await fs.writeFileSync(dataFilePath, data);
         await utils.cache.save(dataFilePath, { ttl: feed.ttl });
         console.log('Fetched and cached: ', chalk.yellow(feed.url), chalk.gray(`(TTL:${feed.ttl} seconds)`));
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-const fs        = require('fs');
-const chalk     = require('chalk');
-const fetchData = require('./fetchData');
+const chalk       = require('chalk');
+const processFeed = require('./processFeed');
 
 module.exports = {
 
@@ -8,24 +7,10 @@ module.exports = {
 
     // Gather the data from all the specified feeds
     for (const feed of inputs.feeds) {
-
-      // Where fetched data should reside in the buid
-      let dataFilePath = `${inputs.dataDir}/${feed.name}.json`;
-
-      // reinstate from cache if it is present
-      if ( await utils.cache.has(dataFilePath) ) {
-        await utils.cache.restore(dataFilePath);
+      if (await processFeed(utils.cache, inputs.dataDir, feed)) {
         console.log('Restored from cache:', chalk.green(feed.url));
-      }
-      // Or if it's not cached, let's fetch it and cache it.
-      else {
-        const data = await fetchData(feed);
-
-        // put the fetched data in the daa file, and then cache it.
-        await fs.writeFileSync(dataFilePath, data);
-        await utils.cache.save(dataFilePath, { ttl: feed.ttl });
+      } else {
         console.log('Fetched and cached: ', chalk.yellow(feed.url), chalk.gray(`(TTL:${feed.ttl} seconds)`));
-
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/philhawksworth/netlify-plugin-fetch-feeds"
   },
+  "scripts": {
+    "test": "tape test/*.js"
+  },
   "keywords": [
     "netlify",
     "rss",
@@ -23,5 +26,8 @@
     "chalk": "^4.0.0",
     "node-fetch": "^2.6.0",
     "xml2json": "^0.12.0"
+  },
+  "devDependencies": {
+    "tape": "^5.0.1"
   }
 }

--- a/processFeed.js
+++ b/processFeed.js
@@ -3,7 +3,7 @@ const fetchData = require('./fetchData');
 
 module.exports = async function (cache, dataDir, feed) {
   // Where fetched data should reside in the buid
-  let dataFilePath = `${dataDir}/${feed.name}.json`;
+  const dataFilePath = `${dataDir}/${feed.name}${feed.type === 'direct' ? '' : '.json'}`;
 
   // reinstate from cache if it is present
   if ( await cache.has(dataFilePath) ) {

--- a/processFeed.js
+++ b/processFeed.js
@@ -1,0 +1,22 @@
+const fs        = require('fs');
+const fetchData = require('./fetchData');
+
+module.exports = async function (cache, dataDir, feed) {
+  // Where fetched data should reside in the buid
+  let dataFilePath = `${dataDir}/${feed.name}.json`;
+
+  // reinstate from cache if it is present
+  if ( await cache.has(dataFilePath) ) {
+    await cache.restore(dataFilePath);
+    return true;
+  }
+  // Or if it's not cached, let's fetch it and cache it.
+  else {
+    const data = await fetchData(feed);
+
+    // put the fetched data in the daa file, and then cache it.
+    await fs.writeFileSync(dataFilePath, data);
+    await cache.save(dataFilePath, { ttl: feed.ttl });
+    return false;
+  }
+}

--- a/test/fetchData.js
+++ b/test/fetchData.js
@@ -1,0 +1,66 @@
+const test = require('tape');
+const http = require('http');
+const fetchData = require('../fetchData');
+
+async function simpleServer (response, contentType) {
+  const server = http.createServer((_, res) => {
+    if (contentType) {
+      res.setHeader('Content-Type', contentType);
+    }
+    res.end(response);
+  });
+  await new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(resolve);
+  });
+  return { server, url: `http://localhost:${server.address().port}` };
+}
+
+async function serveAndFetch({ content, contentType, feed = {} }, handler) {
+  const { server, url } = await simpleServer(content, contentType);
+  try {
+    feed.url = url;
+    return handler({ data: await fetchData(feed), feed });
+  } finally {
+    server.close();
+  }
+}
+
+test('fetching json data', async t => {
+  const content = '{"hello":"world"}';
+  await serveAndFetch({
+    content,
+    contentType: 'application/json'
+  }, ({ data: received }) => {
+    t.equals(received, content, 'content is fetched from server');
+  });
+});
+
+test('fetching json data - header case shouldnt matter', async t => {
+  const content = '{"hello":"world"}';
+  await serveAndFetch({
+    content,
+    contentType: 'APPLICATION/jSoN'
+  }, ({ data: received }) => {
+    t.equals(received, content, 'content is fetched from server');
+  });
+});
+
+test('reformatting json data', async t => {
+  const content = '{ "hello": "world" }';
+  await serveAndFetch({
+    content,
+    contentType: 'application/json'
+  }, ({ data: received }) => {
+    t.equals(received, '{"hello":"world"}', 'content is reformatted');
+  });
+});
+
+test('html content', async t => {
+  await serveAndFetch({
+    content: '<html><body><![CDATA[hi]]></body></html>',
+    contentType: 'text/html'
+  }, ({ data }) => {
+    t.equals(data, '{"html":{"body":"hi"}}', 'html content is turned into structured json');
+  });
+});

--- a/test/fetchData.js
+++ b/test/fetchData.js
@@ -64,3 +64,11 @@ test('html content', async t => {
     t.equals(data, '{"html":{"body":"hi"}}', 'html content is turned into structured json');
   });
 });
+
+test('html content without contentType', async t => {
+  await serveAndFetch({
+    content: '<html><body><![CDATA[hi]]></body></html>',
+  }, ({ data }) => {
+    t.equals(data, '{"html":{"body":"hi"}}', 'html content is returned even though contentType is not given');
+  });
+});

--- a/test/fetchData.js
+++ b/test/fetchData.js
@@ -58,3 +58,15 @@ test('html content without contentType', async t => {
     t.equals(data, '{"html":{"body":"hi"}}', 'html content is returned even though contentType is not given');
   });
 });
+
+test('binary content without contentType, with direct-flag', async t => {
+  const content = '<html><body><![CDATA[hi]]></body></html>';
+  await serveAndFetch({
+    content,
+    feed: {
+      type: 'direct'
+    }
+  }, ({ data }) => {
+    t.equals(Buffer.from(data).toString(), content, 'fetching directly will not add any transformation');
+  });
+});

--- a/test/fetchData.js
+++ b/test/fetchData.js
@@ -1,23 +1,9 @@
 const test = require('tape');
-const http = require('http');
+const simpleServer = require('./util/simpleServer');
 const fetchData = require('../fetchData');
 
-async function simpleServer (response, contentType) {
-  const server = http.createServer((_, res) => {
-    if (contentType) {
-      res.setHeader('Content-Type', contentType);
-    }
-    res.end(response);
-  });
-  await new Promise((resolve, reject) => {
-    server.on('error', reject);
-    server.listen(resolve);
-  });
-  return { server, url: `http://localhost:${server.address().port}` };
-}
-
 async function serveAndFetch({ content, contentType, feed = {} }, handler) {
-  const { server, url } = await simpleServer(content, contentType);
+  const { server, url } = await simpleServer({ content, contentType });
   try {
     feed.url = url;
     return handler({ data: await fetchData(feed), feed });

--- a/test/processFeed.js
+++ b/test/processFeed.js
@@ -1,0 +1,53 @@
+const test = require('tape');
+const simpleServer = require('./util/simpleServer');
+const processFeed = require('../processFeed');
+const path = require('path');
+const tmpPath = path.join(__dirname, '_tmp');
+const fs = require('fs').promises;
+
+test('non-cached data is fetched', async t => {
+  await fs.mkdir(tmpPath, { recursive: true });
+  const name = 'non-cached';
+  const expectedPath = path.join(tmpPath, `${name}.json`);
+  const { server, url } = await simpleServer('{}', 'application/json');
+  const feed = { name, url, ttl: 10 };
+  try {
+    const result = await processFeed({ 
+      has: () => false,
+      save: (dataPath, options) => {
+        t.equals(dataPath, expectedPath, 'the expected data path is based on the feeds name and the dataDir');
+        t.deepEqual(options, {
+          ttl: 10
+        }, 'ttl options get passed through');
+      }
+    }, tmpPath, feed);
+    t.equals(result, false, 'returns false to indicate that the data was loaded');
+    const storedOnDisk = await fs.readFile(expectedPath, 'utf-8');
+    t.equals(storedOnDisk, '{}', 'data got stored on disk');
+  } finally {
+    server.close();
+    try {
+      await fs.unlink(expectedPath);
+    } catch(_) {}
+  }
+});
+
+test('cached data is restored', async t => {
+  const name = 'non-cached';
+  const expectedPath = path.join(tmpPath, `${name}.json`);
+  const url = null;
+  const feed = { name, url, ttl: 10 };
+  let restoreCalled = false;
+  const result = await processFeed({ 
+    has: () => true,
+    restore: async restorePath => {
+      restoreCalled = true;
+      t.equals(restorePath, expectedPath, 'the expected data path is based on the feeds name and the dataDir');
+    },
+    save: () => {
+      throw new Error('shouldnt save');
+    }
+  }, tmpPath, feed);
+  t.equals(result, true, 'returns true to indicate that it was restored from cache');
+  t.equals(restoreCalled, true, 'restore was called');
+});

--- a/test/processFeed.js
+++ b/test/processFeed.js
@@ -51,3 +51,23 @@ test('cached data is restored', async t => {
   t.equals(result, true, 'returns true to indicate that it was restored from cache');
   t.equals(restoreCalled, true, 'restore was called');
 });
+
+test('direct data comes without .json marker', async t => {
+  const name = 'non-cached';
+  const expectedPath = path.join(tmpPath, name);
+  const url = null;
+  const feed = { name, url, ttl: 10, type: 'direct' };
+  let restoreCalled = false;
+  const result = await processFeed({ 
+    has: () => true,
+    restore: async restorePath => {
+      restoreCalled = true;
+      t.equals(restorePath, expectedPath, 'the expected data path is based on the feeds name and the dataDir');
+    },
+    save: () => {
+      throw new Error('shouldnt save');
+    }
+  }, tmpPath, feed);
+  t.equals(result, true, 'returns true to indicate that it was restored from cache');
+  t.equals(restoreCalled, true, 'restore was called');
+});

--- a/test/util/simpleServer.js
+++ b/test/util/simpleServer.js
@@ -1,0 +1,16 @@
+const http = require('http');
+
+module.exports = async function simpleServer ({ content, contentType, statusCode = 200 }) {
+  const server = http.createServer((_, res) => {
+    if (contentType) {
+      res.setHeader('Content-Type', contentType);
+    }
+    res.statusCode = statusCode;
+    res.end(content);
+  });
+  await new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(resolve);
+  });
+  return { server, url: `http://localhost:${server.address().port}` };
+}


### PR DESCRIPTION
This PR adds the ability to specify a `direct = true` flag that directly downloads the data without processing for non-supported data types _(such as .csv, .ical or images)_.

- To make sure that this PR doesn't break things I added basic `tape` tests.
- As there are no lint settings specified (#10) I just formatted it following best effort.


_Note 1: This PR also fixes in 02a5f8b8886fa1bdd5c1dc54eecaa70fcc2b9707 also a bug where the server might skip on returning a content-type._
_Note 2: In a follow-up step it might be a good idea to add a github action for this test_